### PR TITLE
Added Fluent Validation

### DIFF
--- a/Aeveco.AzureFunction/Aeveco.AzureFunction.csproj
+++ b/Aeveco.AzureFunction/Aeveco.AzureFunction.csproj
@@ -1,11 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
+    <PackageReference Include="FluentValidation" Version="11.4.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
     <PackageReference Include="QRCoder" Version="1.4.3" />
   </ItemGroup>
   <ItemGroup>

--- a/Aeveco.AzureFunction/Application/Models/UrlQRRequest.cs
+++ b/Aeveco.AzureFunction/Application/Models/UrlQRRequest.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Aeveco.AzureFunction.Application.Models
+{
+    public class UrlQRRequest
+    {
+        public string? Url { get; set; }
+    }
+}

--- a/Aeveco.AzureFunction/Application/Models/WifiQRRequest.cs
+++ b/Aeveco.AzureFunction/Application/Models/WifiQRRequest.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Aeveco.AzureFunction.Application.Models
+{
+    public class WifiQRRequest
+    {
+        public string? WifiName { get; set; }
+        public string? Passcode { get; set; }
+    }
+}

--- a/Aeveco.AzureFunction/Application/Validation/UrlQRRequestValidator.cs
+++ b/Aeveco.AzureFunction/Application/Validation/UrlQRRequestValidator.cs
@@ -1,0 +1,18 @@
+﻿using Aeveco.AzureFunction.Application.Models;
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Aeveco.AzureFunction.Application.Validation
+{
+    public class UrlQRRequestValidator:AbstractValidator<UrlQRRequest>
+    {
+        public UrlQRRequestValidator()
+        {
+            RuleFor(x => x.Url).NotEmpty().MinimumLength(10);
+        }
+    }
+}

--- a/Aeveco.AzureFunction/Application/Validation/UrlQRRequestValidator.cs
+++ b/Aeveco.AzureFunction/Application/Validation/UrlQRRequestValidator.cs
@@ -12,7 +12,15 @@ namespace Aeveco.AzureFunction.Application.Validation
     {
         public UrlQRRequestValidator()
         {
-            RuleFor(x => x.Url).NotEmpty().MinimumLength(10);
+            RuleFor(x => x.Url).NotEmpty().MinimumLength(10).Custom((val, context)=>{
+                if (!(val.StartsWith("https://", StringComparison.OrdinalIgnoreCase) || val.StartsWith("http://", StringComparison.OrdinalIgnoreCase))) {
+                    context.AddFailure("Must stat with https:// or https://");
+                }
+                if (!Uri.TryCreate(val, UriKind.RelativeOrAbsolute, out Uri? myUri))
+                {
+                    context.AddFailure($"'{val}' is not a valid url.");
+                }
+            });
         }
     }
 }

--- a/Aeveco.AzureFunction/Application/Validation/ValidatableRequest.cs
+++ b/Aeveco.AzureFunction/Application/Validation/ValidatableRequest.cs
@@ -1,0 +1,29 @@
+﻿using FluentValidation.Results;
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Newtonsoft.Json;
+using System.Threading.Tasks;
+using Aeveco.AzureFunction.Application.Validation;
+using System.Collections.Generic;
+
+namespace Aeveco.AzureFunction.Application.Validation
+{
+    public class ValidatableRequest<T>
+    {
+        /// <summary>
+        /// The deserialized value of the request.
+        /// </summary>
+        public T? Value { get; set; }
+
+        /// <summary>
+        /// Whether or not the deserialized value was found to be valid.
+        /// </summary>
+        public bool IsValid { get; set; }
+
+        /// <summary>
+        /// The collection of validation errors.
+        /// </summary>
+        public IList<ValidationFailure>? Errors { get; set; }
+    }
+}

--- a/Aeveco.AzureFunction/Application/Validation/WifiQRRequestValidator.cs
+++ b/Aeveco.AzureFunction/Application/Validation/WifiQRRequestValidator.cs
@@ -1,0 +1,19 @@
+﻿using Aeveco.AzureFunction.Application.Models;
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Aeveco.AzureFunction.Application.Validation
+{
+    public class WifiQRRequestValidator : AbstractValidator<WifiQRRequest>
+    {
+        public WifiQRRequestValidator()
+        {
+            RuleFor(x => x.WifiName).NotEmpty().MaximumLength(200);
+            RuleFor(x => x.Passcode).NotEmpty().MaximumLength(200);
+        }
+    }
+}

--- a/Aeveco.AzureFunction/Extensions/HttpRequestExtensions.cs
+++ b/Aeveco.AzureFunction/Extensions/HttpRequestExtensions.cs
@@ -1,0 +1,76 @@
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Newtonsoft.Json;
+using System.Threading.Tasks;
+using Aeveco.AzureFunction.Application.Validation;
+using System.Collections.Generic;
+using FluentValidation.Results;
+
+namespace Aeveco.AzureFunction.Extensions
+{
+    /// <summary>
+    /// Totally swiped from theis great article
+    /// https://www.tomfaltesek.com/azure-functions-input-validation/
+    /// </summary>
+    public static class HttpRequestExtensions
+    {
+        /// <summary>
+        /// Returns the deserialized request body with validation information.
+        /// </summary>
+        /// <typeparam name="T">Type used for deserialization of the request body.</typeparam>
+        /// <typeparam name="V">
+        /// Validator used to validate the deserialized request body.
+        /// </typeparam>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public static async Task<ValidatableRequest<T>> GetJsonBody<T, V>(this HttpRequest request)
+            where V : AbstractValidator<T>, new()
+        {
+            var requestObject = await request.GetJsonBody<T>();
+            
+            // if the requestObject is null
+            if (requestObject == null) {
+                return new ValidatableRequest<T>
+                {
+                    Value = requestObject,
+                    IsValid = false
+                };
+            }
+
+            var validator = new V();
+            var validationResult = validator.Validate(requestObject);
+
+            if (!validationResult.IsValid)
+            {
+                return new ValidatableRequest<T>
+                {
+                    Value = requestObject,
+                    IsValid = false,
+                    Errors = validationResult.Errors
+                };
+            }
+
+            return new ValidatableRequest<T>
+            {
+                Value = requestObject,
+                IsValid = true
+            };
+        }
+
+        /// <summary>
+        /// Returns the deserialized request body.
+        /// </summary>
+        /// <typeparam name="T">Type used for deserialization of the request body.</typeparam>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public static async Task<T?> GetJsonBody<T>(this HttpRequest request)
+        {
+            var requestBody = await request.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(requestBody)) {
+                return default;
+            }
+            return JsonConvert.DeserializeObject<T>(requestBody);
+        }
+    }
+}

--- a/Aeveco.AzureFunction/Extensions/HttpRequestExtensions.cs
+++ b/Aeveco.AzureFunction/Extensions/HttpRequestExtensions.cs
@@ -28,7 +28,7 @@ namespace Aeveco.AzureFunction.Extensions
             where V : AbstractValidator<T>, new()
         {
             var requestObject = await request.GetJsonBody<T>();
-            
+
             // if the requestObject is null
             if (requestObject == null) {
                 return new ValidatableRequest<T>

--- a/Aeveco.AzureFunction/Extensions/ValidationExtensions.cs
+++ b/Aeveco.AzureFunction/Extensions/ValidationExtensions.cs
@@ -19,7 +19,7 @@ namespace Aeveco.AzureFunction.Extensions
         public static BadRequestObjectResult ToBadRequest<T>(this ValidatableRequest<T> request)
         {
             if (request.Errors == null) {
-                return new BadRequestObjectResult("Bad Validation");
+                return new BadRequestObjectResult("Unable to Validate Form Body");
             }
             return new BadRequestObjectResult(request.Errors.Select(e => new {
                 Field = e.PropertyName,

--- a/Aeveco.AzureFunction/Extensions/ValidationExtensions.cs
+++ b/Aeveco.AzureFunction/Extensions/ValidationExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Aeveco.AzureFunction.Application.Validation;
+
+namespace Aeveco.AzureFunction.Extensions
+{
+    public static class ValidationExtensions
+    {
+        /// <summary>
+        /// Creates a <see cref="BadRequestObjectResult"/> containing a collection
+        /// of minimal validation error details.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public static BadRequestObjectResult ToBadRequest<T>(this ValidatableRequest<T> request)
+        {
+            if (request.Errors == null) {
+                return new BadRequestObjectResult("Bad Validation");
+            }
+            return new BadRequestObjectResult(request.Errors.Select(e => new {
+                Field = e.PropertyName,
+                Error = e.ErrorMessage
+            }));
+        }
+    }
+}

--- a/Aeveco.AzureFunction/Hello.cs
+++ b/Aeveco.AzureFunction/Hello.cs
@@ -21,7 +21,7 @@ namespace Aeveco.AzureFunction
 
             string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
 
-            dynamic data = JsonConvert.DeserializeObject(requestBody);
+            dynamic? data = JsonConvert.DeserializeObject(requestBody);
 
             // prefer the body or grab the name
             string? name = data?.name ?? req.Query["name"];

--- a/Aeveco.AzureFunction/UrlQR.cs
+++ b/Aeveco.AzureFunction/UrlQR.cs
@@ -8,6 +8,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using QRCoder;
+using Aeveco.AzureFunction.Extensions;
+using Aeveco.AzureFunction.Application.Models;
+using Aeveco.AzureFunction.Application.Validation;
 
 namespace Aeveco.AzureFunction
 {
@@ -18,27 +21,33 @@ namespace Aeveco.AzureFunction
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequest req,
             ILogger log)
         {
-            log.LogInformation("URL HTTP trigger function processed a request.");
+            // grab the request form
+            var form = await req.GetJsonBody<UrlQRRequest, UrlQRRequestValidator>();
 
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            dynamic data = JsonConvert.DeserializeObject(requestBody);
-            // prefer the body or grab the name
-            string? urlValue = data?.url ?? req.Query["url"];
-
-            if (string.IsNullOrEmpty(urlValue))
+            if (!form.IsValid)
             {
-                return new BadRequestObjectResult("Please supply a url to encode");
+                log.LogInformation("Invalid form data.");
+                return form.ToBadRequest();
             }
 
+            //string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            //dynamic? data = JsonConvert.DeserializeObject(requestBody);
+            //// prefer the body or grab the name
+            //string? urlValue = data?.url ?? req.Query["url"];
 
-            PayloadGenerator.Url generator = new(urlValue);
+            //if (string.IsNullOrEmpty(urlValue))
+            //{
+            //    return new BadRequestObjectResult("Please supply a url to encode");
+            //}
+
+            PayloadGenerator.Url generator = new(form.Value?.Url);
+
             string payload = generator.ToString();
 
             QRCodeGenerator qrGenerator = new();
             QRCodeData qrCodeData = qrGenerator.CreateQrCode(payload, QRCodeGenerator.ECCLevel.Q);
             PngByteQRCode qrCode = new(qrCodeData);
             var qrCodeAsPng = qrCode.GetGraphic(20);
-
 
             return new FileContentResult(qrCodeAsPng, "image/png");
         }

--- a/Aeveco.AzureFunction/WifiQR.cs
+++ b/Aeveco.AzureFunction/WifiQR.cs
@@ -1,3 +1,6 @@
+using Aeveco.AzureFunction.Application.Models;
+using Aeveco.AzureFunction.Application.Validation;
+using Aeveco.AzureFunction.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
@@ -17,21 +20,16 @@ namespace Aeveco.AzureFunction
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequest req,
             ILogger log)
         {
-            log.LogInformation("C# HTTP trigger function processed a request.");
+            // grab the request form
+            var form = await req.GetJsonBody<WifiQRRequest, WifiQRRequestValidator>();
 
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            dynamic data = JsonConvert.DeserializeObject(requestBody);
-            // prefer the body or grab the name
-            string? wifiName = data?.wifiname ?? req.Query["wifiname"];
-            string? passcode = data?.passcode ?? req.Query["passcode"];
-
-            if (string.IsNullOrEmpty(wifiName) || string.IsNullOrEmpty(passcode))
+            if (!form.IsValid)
             {
-                return new BadRequestObjectResult("Please supply a wifiname and a passcode");
+                log.LogInformation("Invalid form data.");
+                return form.ToBadRequest();
             }
 
-
-            PayloadGenerator.WiFi generator = new(wifiName, passcode, PayloadGenerator.WiFi.Authentication.WPA);
+            PayloadGenerator.WiFi generator = new(form.Value?.WifiName, form.Value?.Passcode, PayloadGenerator.WiFi.Authentication.WPA);
             string payload = generator.ToString();
 
             QRCodeGenerator qrGenerator = new();
@@ -39,9 +37,7 @@ namespace Aeveco.AzureFunction
             PngByteQRCode qrCode = new(qrCodeData);
             var qrCodeAsPng = qrCode.GetGraphic(20);
 
-
             return new FileContentResult(qrCodeAsPng, "image/png");
-
         }
     }
 }


### PR DESCRIPTION
Just added simple DTOs for incoming JSON body requests.  Earlier version worked with query strings and forms, but this breaks that functionality.  May need to change the de serialization to work with query strings and form submissions